### PR TITLE
Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,42 @@
+# Java
+*.class
+*.jar
+*.war
+*.ear
+
+# Eclipse
+/.classpath
+/.project
+/.settings/
+
+# IntelliJ
+/.idea/
+/*.iml
+/out/
+
+# VS Code
+/.vscode/
+
+# Maven
 /target/
+/pom.xml.tag
+/pom.xml.releaseBackup
+/pom.xml.versionsBackup
+/logging.properties
+/release.properties
+
+# Hibernate
+/hibernate.cfg.xml
+
+# JPA
+/META-INF/persistence.xml
+
+# MySQL
+/mysql-connector-java-*.jar
+
+# Logs
+*.log
+
+# Ficheiros gerados pelo sistema operativo
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Ficheiros e pastas a ignorar (Java, Eclipse, IntelliJ, VS Code, Maven, Hibernate, JPA, MySQL, Logs e OS files)